### PR TITLE
Support setting explicit path to Code command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ time you load the repositories list. It's **false** by default.
         "gitProjectManager.storeRepositoriesBetweenSessions": true
     }
 
+If nothing happens when trying to open a found project it could be due to the Code command being used. To work around this issue set **gitProjectManager.codePath** to the full path of the Code command to use when launching new instances. For example:
+
+
+    {
+        "gitProjectManager.codePath": "C:\\Program Files (x86)\\Microsoft VS Code\\bin\\code.cmd"
+    }
 
 ##Available commands
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
           "type": "boolean",
           "default": false,
           "description": "Specifies whether saves repository folders' data between sessions"
+        },
+        "gitProjectManager.codePath": {
+            "type": "string",
+            "default": "code",
+            "description": "Specifies full path to Code command to use when opening a project." 
         }
       }
     },

--- a/src/gitProjectManager.js
+++ b/src/gitProjectManager.js
@@ -140,7 +140,12 @@ exports.getProjectsList = (directories) => {
 
 exports.openProject = (pickedObj) => {
     var cp = require('child_process');
-    var cmdLine = 'code "' + pickedObj.label + '" -r';
+    var codePath = vscode.workspace.getConfiguration(
+        'gitProjectManager'
+    ).get(
+        'codePath', 'code'
+    );
+    var cmdLine = '"' + codePath + '" "' + pickedObj.label + '" -r';
         
     if (process.platform == 'linux') {
         cp.spawn(process.execPath, ['.'], {cwd: path.dirname(process.execPath), detached: true}, (err, stdout, stdErr) => {


### PR DESCRIPTION
Provide workaround for part of #1 where `code.cmd` is required as Code command on Windows.

### Test

* Confirm that not setting new configuration value for *gitProjectManager.codePath* does not cause a regression.
* Confirm that setting appropriate configuration value for *gitProjectManager.codePath* fixes issue with opening projects (on Windows at least).