### PR TITLE
Add .vscode-test to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode-test
 node_modules
 *.vsix


### PR DESCRIPTION
This directory stores a downloaded test version of vscode when the test
command is run.