### PR TITLE
Use a promise for openProject command

### DIFF
--- a/src/gitProjectManager.js
+++ b/src/gitProjectManager.js
@@ -114,13 +114,11 @@ exports.showProjectList = () => {
     }
 
     var options = { placeHolder: 'Select a folder to open:      (it may take a few seconds to search the folders the first time)' };
-    getProjectsFolders()
-        .then((folders) => {
-            this.getProjectsList(folders)
-                .then(items => vscode.window.showQuickPick(items, options)
-                .then(onResolve, onReject));
-        })
-        .catch(handleError);
+    
+    var projectsPromise = getProjectsFolders().then((folders) => {
+        return this.getProjectsList(folders);
+    }).catch(handleError);
+    vscode.window.showQuickPick(projectsPromise, options).then(onResolve, onReject);
 };
 
 


### PR DESCRIPTION
This makes the quick pick dialog appear immediately so the search term can be
typed in immediately.

Fixes #24