### PR TITLE
Remove refresh list message after timeout

### DIFF
--- a/src/gitProjectManager.js
+++ b/src/gitProjectManager.js
@@ -246,7 +246,7 @@ function internalRefresh(folders, suppressMessage) {
     exports.getProjectsList(folders)
         .then(() => {
             if (!suppressMessage) {
-                vscode.window.setStatusBarMessage('Git Project Manager - Project List Refreshed');
+                vscode.window.setStatusBarMessage('Git Project Manager - Project List Refreshed', 3000);
             }
         })
         .catch((error) => {


### PR DESCRIPTION
Right now it never clears out, forcing a full refresh of VSCode to remove the message.

The initial proposed timeout is only a suggestion to kick off the PR; there's no higher reasoning informing its selection other than "this seems like a good enough time".