### PR TITLE
Added compatibility with windows home path

### DIFF
--- a/src/gitProjectManager.js
+++ b/src/gitProjectManager.js
@@ -143,7 +143,8 @@ class GitProjectManager {
             return process.env[key];
         });
 
-        return resolvedPath.charAt(0) == '~' ? path.join(process.env.HOME, resolvedPath.substr(1)) : resolvedPath;
+        const homePath = process.env.HOME || process.env.HOMEPATH;
+        return resolvedPath.charAt(0) == '~' ? path.join(homePath, resolvedPath.substr(1)) : resolvedPath;
     };
     /**
      * Show the list of found Git projects, and open the choosed project


### PR DESCRIPTION
While I usually develop on a mac, I thought I'd take the new [`BashOnWindows`](https://github.com/Microsoft/BashOnWindows) stuff for a spin.  This was one blocker, though I believe there are some additional blockers with regards to locating `git` etc.  Happy to work through these to keep resolving those if that's something of interest to you.