### PR TITLE
README has default max depth recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To improve performance there are 2 new and important configurations that are:
         "gitProjectManager.ignoredFolders": ["node_modules"]
     }
 
-**maxDepthRecursion**: indicates the maximum recursion depth that will be searched starting in the configured folder
+**maxDepthRecursion**: indicates the maximum recursion depth that will be searched starting in the configured folder (default: `2`)
 
     {
         "gitProjectManager.maxDepthRecursion": 4


### PR DESCRIPTION
I was wondering what the default value for `maxDepthRecursion`. I didn't find the information in the `README`. I think I found it [in the code](https://github.com/felipecaputo/git-project-manager/blob/1d6aba09affbb2b2d2defbdb9d69b5992c14fa73/src/config.js#L9).

I added the value to the README file.