### PR TITLE
shortcut openRecents overlaps with logout shortcut on MacOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
             },
             {
                 "key": "ctrl+shift+q",
-                "mac": "cmd+shift+q",
+                "mac": "cmd+alt+q",
                 "command": "gitProjectManager.openRecents"
             }
         ]


### PR DESCRIPTION
cmd+shift+q is a globally bound shortcut for logging out the current user and closing all applications.

Replacing the `shift` part of the shortcut with `alt` fixes this issue and allows the shortcut to be actually used.