### PR TITLE
Extension not loading in some cases

### DIFF
--- a/src/recentItems.js
+++ b/src/recentItems.js
@@ -11,22 +11,22 @@ class RecentItems {
      * @param {string} pathToSave Path where the RecentItems file will be saved
      */
     constructor(pathToSave) {
-            this.pathToSave = pathToSave;
-            this.listSize = 5;
-            this.list = [];
-            this.loadFromFile();
-        }
-        /**
-         * Returns the full path to recent projects file
-         * 
-         * @returns {string}
-         */
+        this.pathToSave = pathToSave;
+        this.listSize = 5;
+        this.list = [];
+        this.loadFromFile();
+    }
+    /**
+     * Returns the full path to recent projects file
+     * 
+     * @returns {string}
+     */
     getPathToFile() {
         return path.join(this.pathToSave, RECENT_FILE_NAME);
     }
     loadFromFile() {
         const filePath = this.getPathToFile();
-        if (fs.existsSync(filePath)) {
+        if (fs.existsSync(filePath) && typeof filepath !== 'undefined') {
             this.list = JSON.parse(fs.readFileSync(filePath, 'utf8'));
         }
     }

--- a/src/recentItems.js
+++ b/src/recentItems.js
@@ -26,7 +26,7 @@ class RecentItems {
     }
     loadFromFile() {
         const filePath = this.getPathToFile();
-        if (fs.existsSync(filePath) && typeof filepath !== 'undefined') {
+        if (fs.existsSync(filePath) && typeof filePath !== 'undefined') {
             this.list = JSON.parse(fs.readFileSync(filePath, 'utf8'));
         }
     }


### PR DESCRIPTION
This could fix #53 . This bug was triggering when the extension couldn't find the filePath (because it dosen't exist or other reasons). Checking if the filePath is undefined resolved this issue and allows the extension to be loaded by VSCode.