### PR TITLE
Add an option to display project paths in project picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Define if extension should look for for SVN projects too."
+                },
+                "gitProjectManager.displayProjectPath": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Indicates if project path will be displayed in project picker."
                 }
             }
         },

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,7 @@ class Config {
         this.searchInsideProjects = true;
         this.supportsMercurial = false;
         this.supportsSVN = false;
+        this.displayProjectPath = false;
 
         if (vscodeCfg)
             this.loadConfigFromVsCode(vscodeCfg)
@@ -36,6 +37,7 @@ class Config {
         this.searchInsideProjects = vscodeConfig.get('searchInsideProjects', true);
         this.supportsMercurial = vscodeConfig.get('supportsMercurial', false);
         this.supportsSVN = vscodeConfig.get('supportsSVN', false);
+        this.displayProjectPath = vscodeConfig.get('displayProjectPath', false);
     }
 }
 

--- a/src/gitProjectManager.js
+++ b/src/gitProjectManager.js
@@ -65,7 +65,7 @@ class GitProjectManager {
             }
             return {
                 label: repo.name,
-                description: description,
+                description: description.trim(),
             };
         });
     }

--- a/src/gitProjectManager.js
+++ b/src/gitProjectManager.js
@@ -51,13 +51,17 @@ class GitProjectManager {
         });
 
         return this.repoList.map(repo => {
-            let description;
-            if (this.config.checkRemoteOrigin && this.config.displayProjectPath) {
-                description = `${GLOBE} ${repo.repo} ${FOLDER} ${repo.dir}`;
-            } else if (this.config.checkRemoteOrigin) {
-                description = `${GLOBE} ${repo.repo}`;
-            } else {
-                description = `${FOLDER} ${repo.dir}`;
+            let description = '';
+            if (this.config.displayProjectPath || !this.config.checkRemoteOrigin) {
+                let homeDir = process.env.HOME.replace(new RegExp(`${path.sep}$`), '') + path.sep;
+                let repoDir = repo.dir;
+                if (repoDir.startsWith(homeDir)) {
+                    repoDir = '~/' + repoDir.substring(homeDir.length);
+                }
+                description = `${FOLDER} ${repoDir}`;
+            }
+            if (this.config.checkRemoteOrigin) {
+                description = `${GLOBE} ${repo.repo} ` + description;
             }
             return {
                 label: repo.name,

--- a/src/gitProjectManager.js
+++ b/src/gitProjectManager.js
@@ -10,6 +10,9 @@ const SHA256 = require('crypto-js').SHA256;
 const RecentItems = require('./recentItems');
 let ProjectLocator = require('./gitProjectLocator');
 
+const FOLDER = '\uD83D\uDCC2';
+const GLOBE = '\uD83C\uDF10';
+
 class GitProjectManager {
     /**
      * Creates an instance of GitProjectManager.
@@ -48,9 +51,17 @@ class GitProjectManager {
         });
 
         return this.repoList.map(repo => {
+            let description;
+            if (this.config.checkRemoteOrigin && this.config.displayProjectPath) {
+                description = `${GLOBE} ${repo.repo} ${FOLDER} ${repo.dir}`;
+            } else if (this.config.checkRemoteOrigin) {
+                description = `${GLOBE} ${repo.repo}`;
+            } else {
+                description = `${FOLDER} ${repo.dir}`;
+            }
             return {
                 label: repo.name,
-                description: this.config.checkRemoteOrigin ? repo.repo : repo.dir
+                description: description,
             };
         });
     }


### PR DESCRIPTION
This option is useful when trying to distinguish between several identically named projects.

## Current behavior
When `checkRemoteOrigin` is enabled (default), `origin` URL is displayed (or the word "origin" if there's no URL, like on the screenshots below):
![selection_071](https://user-images.githubusercontent.com/699961/45694614-4dbc9e80-bb68-11e8-9b5f-d3b57e058968.png)

When `checkRemoteOrigin` is disabled, the project path is displayed:
![selection_072](https://user-images.githubusercontent.com/699961/45694650-5dd47e00-bb68-11e8-9b86-e2abb06c43a3.png)

## Suggested behavior
This PR adds an option called `displayProjectPath` that enables displaying project paths regardless of `checkRemoteOrigin` value.

When `checkRemoteOrigin` is enabled and `displayProjectPath` is disabled (these will be the default settings), origin` URL is displayed (or the word "origin" if there's no URL) like before:
![selection_073](https://user-images.githubusercontent.com/699961/45694759-a55b0a00-bb68-11e8-8d1c-57e7bd6930df.png)

When both `checkRemoteOrigin` and  `displayProjectPath` are enabled, both the remote URL and the project path are displayed:
![selection_074](https://user-images.githubusercontent.com/699961/45694845-d3404e80-bb68-11e8-8a38-3de61f40d573.png)

When both `checkRemoteOrigin` and  `displayProjectPath` are disabled, only the project path is displayed:
![selection_075](https://user-images.githubusercontent.com/699961/45695100-64172a00-bb69-11e8-8928-4d5de78e630e.png)

