### PR TITLE
Refactor extension state persistence

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,10 @@ class Config {
         this.supportsSVN = vscodeConfig.get('supportsSVN', false);
         this.displayProjectPath = vscodeConfig.get('displayProjectPath', false);
     }
+
+    get(param, defaultValue = undefined) {
+        return this.hasOwnProperty(param) ? this[param] : defaultValue;
+    }
 }
 
 module.exports = Config;

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,11 +4,11 @@ const vscode = require('vscode');
 const ProjectManager = require('./gitProjectManager');
 const Config = require('./config');
 const cfg = new Config(vscode.workspace.getConfiguration('gitProjectManager'))
-const projectManager = new ProjectManager(cfg);
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 function activate(context) {
+    const projectManager = new ProjectManager(cfg, context.globalState);
 
     let disposable = vscode.commands.registerCommand('gitProjectManager.openProject', function () {
         projectManager.showProjectList(false);

--- a/src/recentItems.js
+++ b/src/recentItems.js
@@ -1,39 +1,14 @@
-const path = require('path');
-const fs = require('fs');
-
-
-const RECENT_FILE_NAME = 'gpm-recentItems.json';
-
 class RecentItems {
     /**
      * Creates an instance of RecentItems.
-     * 
-     * @param {string} pathToSave Path where the RecentItems file will be saved
+     *
+     * @param {Memento} state Global extension state.
+     * @param {number} [listSize=5] Recent items list size.
      */
-    constructor(pathToSave) {
-        this.pathToSave = pathToSave;
-        this.listSize = 5;
-        this.list = [];
-        this.loadFromFile();
-    }
-    /**
-     * Returns the full path to recent projects file
-     * 
-     * @returns {string}
-     */
-    getPathToFile() {
-        return path.join(this.pathToSave, RECENT_FILE_NAME);
-    }
-    loadFromFile() {
-        const filePath = this.getPathToFile();
-        if (fs.existsSync(filePath) && typeof filePath !== 'undefined') {
-            this.list = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-        }
-    }
-    saveToFile() {
-        fs.writeFileSync(this.getPathToFile(), JSON.stringify(this.list), {
-            encoding: 'utf8'
-        });
+    constructor(state, listSize = 5) {
+        this.state = state;
+        this.listSize = listSize;
+        this.list = this.state.get('recent', []);
     }
     addProject(projectPath, gitRepo) {
         const idx = this.list.findIndex(p => p.projectPath === projectPath);
@@ -48,7 +23,7 @@ class RecentItems {
         };
 
         this.sortList();
-        this.saveToFile();
+        this.state.update('recent', this.list);
     }
     sortList() {
         this.list = this.list.sort((a, b) => b.lastUsed - a.lastUsed);

--- a/test/gitProjectManager.test.js
+++ b/test/gitProjectManager.test.js
@@ -6,8 +6,8 @@ const vscode = require('vscode');
 
 const ProjectManager = require('../src/gitProjectManager');
 const Config = require('../src/config');
-const config = new Config();
-const projectManager = new ProjectManager(config)
+const StateMock = require('./stateMock');
+const projectManager = new ProjectManager(new Config(), new StateMock());
 
 describe("gitProjectManager", function () {
     var sandbox;

--- a/test/recentItems.test.js
+++ b/test/recentItems.test.js
@@ -2,12 +2,10 @@
 
 const RecentItems = require('../src/recentItems');
 const expect = require('chai').expect;
-const path = require('path');
-const fs = require('fs');
 const rmdir = require('rmdir');
 const sinon = require('sinon');
 
-const TESTING_PATH = path.join(__dirname, 'recents');
+const StateMock = require('./stateMock');
 
 function addProjectsToList(recentList, size) {
     switch (size) {
@@ -27,19 +25,10 @@ function addProjectsToList(recentList, size) {
 }
 
 describe('RecentItems', () => {
-    let recentItems = new RecentItems(TESTING_PATH);
+    let recentItems;
 
     beforeEach(() => {
-        if (fs.existsSync(TESTING_PATH)) {
-            fs.rmdirSync(TESTING_PATH);
-        }
-        fs.mkdirSync(TESTING_PATH);
-        recentItems = new RecentItems(TESTING_PATH);
-
-    });
-
-    afterEach((done) => {
-        rmdir(TESTING_PATH, {}, () => done())
+        recentItems = new RecentItems(new StateMock());
     });
 
     it('should start with an empty list', () => {
@@ -53,7 +42,7 @@ describe('RecentItems', () => {
 
     it('should load projects on create', () => {
         addProjectsToList(recentItems, 2);
-        const secondInstance = new RecentItems(TESTING_PATH);
+        const secondInstance = new RecentItems(recentItems.state);
         expect(secondInstance.list.length).to.be.equals(2);
     })
 

--- a/test/stateMock.js
+++ b/test/stateMock.js
@@ -1,0 +1,11 @@
+module.exports = class {
+    constructor() {
+        this.data = {};
+    }
+    get(key, defaultValue = undefined) {
+        return this.data.hasOwnProperty(key) ? this.data[key] : defaultValue;
+    }
+    async update(key, value) {
+        this.data[key] = value;
+    }
+}


### PR DESCRIPTION
Uses VSCode's API for extension global persisted state instead of writing the files ourselves.
Should make the extension persistence more future-proof and less buggy.
Fixes #95.