### PR TITLE
Fix error when there is no origin remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next version
+
+- Fixed error that could happen when there are no `origin` remote - #63
+
 ## 1.7.1
 
 - Workaround for #88 where there were erros loading projects from home dir on Ubuntu

--- a/package.json
+++ b/package.json
@@ -193,10 +193,11 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
+    "postcompile": "mkdir -p out/test/suite/repo-info-test && cp -R src/test/suite/repo-info-test/*  out/test/suite/repo-info-test",
     "compile": "./node_modules/typescript/bin/tsc -p ./",
     "lint": "eslint src --ext ts",
     "watch": "./node_modules/typescript/bin/tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile",
     "test": "node ./out/test/runTest.js"
   },
   "dependencies": {}

--- a/src/gitProjectLocator.ts
+++ b/src/gitProjectLocator.ts
@@ -100,20 +100,17 @@ export default class ProjectLocator {
             return;
         }
 
-        var stdout = cp.execSync('git remote show origin -n', { cwd: basePath, encoding: 'utf8' });
-        if (stdout.indexOf('Fetch URL:') === -1) {
+        let originList = cp.execSync('git remote ', { cwd: basePath, encoding: 'utf8' });
+
+        let firstOrigin = originList?.split('\n').shift()?.trim();
+        if (firstOrigin === '') {
             return;
         }
 
-        var arr = stdout.split('\n');
-        for (var i = 0; i < arr.length; i++) {
-            var line = arr[i];
-            var repoPath = 'Fetch URL: ';
-            var idx = line.indexOf(repoPath);
-            if (idx > -1) {
-                return line.trim().replace(repoPath, '');
-            }
-        }
+        return cp.execSync(`git remote get-url ${firstOrigin}`, { cwd: basePath, encoding: 'utf8' })
+            ?.split('\n')
+            .shift()
+            ?.trim();
     }
     processDirectory(absPath: string) {
         vscode.window.setStatusBarMessage(absPath, 600);

--- a/src/test/suite/gitProjectLocator.repoInfo.test.ts
+++ b/src/test/suite/gitProjectLocator.repoInfo.test.ts
@@ -1,0 +1,56 @@
+import ProjectLocator from '../../gitProjectLocator';
+import Config from '../../domain/config';
+import { mkdirSync, chmodSync, writeFileSync } from 'fs';
+import * as rimraf from 'rimraf';
+import { join } from 'path';
+import { expect } from 'chai';
+import { execSync } from 'child_process';
+
+suite('Get repository information', () => {
+
+    let baseFolderName = join(__dirname, 'repo-info-test');
+    let gitConfigFilePath = join(baseFolderName, '.git/config');
+
+    setup(() => {
+        execSync(`mkdir -p ${baseFolderName}/.git && cp -R ${baseFolderName}/base-git/* ${baseFolderName}/.git`);
+
+    })
+
+    teardown(() => {
+        rimraf.sync(join(baseFolderName, '.git'));
+    })
+
+    test('should get information when we have a single remote upstream', () => {
+
+        execSync('git remote add upstream git@github.com:felipecaputo/some-other-project.git', { cwd: baseFolderName });
+
+        const projectLocator = new ProjectLocator(new Config());
+        expect(projectLocator.extractRepoInfo(baseFolderName)).to.equals('git@github.com:felipecaputo/some-other-project.git');
+
+    })
+
+    test('should get information when we have a single remote origin', () => {
+
+        execSync('git remote add origin git@github.com:felipecaputo/git-project-manager-123.git', { cwd: baseFolderName });
+
+        const projectLocator = new ProjectLocator(new Config());
+        expect(projectLocator.extractRepoInfo(baseFolderName)).to.equals('git@github.com:felipecaputo/git-project-manager-123.git');
+
+    })
+
+    test('should get information when we have more than one remote', () => {
+
+        execSync('git remote add origin git@github.com:felipecaputo/git-project-manager-123.git', { cwd: baseFolderName });
+        execSync('git remote add upstream git@github.com:felipecaputo/some-other-project.git', { cwd: baseFolderName });
+
+        const projectLocator = new ProjectLocator(new Config());
+        expect(projectLocator.extractRepoInfo(baseFolderName)).to.equals('git@github.com:felipecaputo/git-project-manager-123.git');
+
+    })
+
+    test('should return empty on no remote', () => {
+        const projectLocator = new ProjectLocator(new Config());
+        expect(projectLocator.extractRepoInfo(baseFolderName)).to.equals(undefined);
+
+    })
+})

--- a/src/test/suite/repo-info-test/base-git/HEAD
+++ b/src/test/suite/repo-info-test/base-git/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/master

--- a/src/test/suite/repo-info-test/base-git/config
+++ b/src/test/suite/repo-info-test/base-git/config
@@ -1,0 +1,7 @@
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	ignorecase = true
+	precomposeunicode = true

--- a/src/test/suite/repo-info-test/base-git/description
+++ b/src/test/suite/repo-info-test/base-git/description
@@ -1,0 +1,1 @@
+Unnamed repository; edit this file 'description' to name the repository.

--- a/src/test/suite/repo-info-test/base-git/info/exclude
+++ b/src/test/suite/repo-info-test/base-git/info/exclude
@@ -1,0 +1,6 @@
+# git ls-files --others --exclude-from=.git/info/exclude
+# Lines that start with '#' are comments.
+# For a project mostly in C, the following would be a good set of
+# exclude patterns (uncomment them if you want to use them):
+# *.[oa]
+# *~


### PR DESCRIPTION
The previous code was looking specifically for a remote
called `origin` but it is not mandatory and could generate errors,
now it searches for all remotes and get the url from the first one