### PR TITLE
Add openInNewWindow option to openRecentProjects.

### DIFF
--- a/src/gitProjectManager.ts
+++ b/src/gitProjectManager.ts
@@ -284,7 +284,7 @@ export default class GitProjectManager {
 
     };
 
-    openRecentProjects() {
+    openRecentProjects(openInNewWindow: boolean = false) {
         let self = this;
         if (this.recentList.list.length === 0) {
             vscode.window.showInformationMessage('It seems you haven\'t opened any projects using Git Project Manager extension yet!');
@@ -297,7 +297,7 @@ export default class GitProjectManager {
             };
         })).then(selected => {
             if (selected) {
-                self.openProject(selected.description);
+                self.openProject(selected.description, openInNewWindow);
             }
         });
     }


### PR DESCRIPTION
"Open Git Project" has the option of openInNewWindow, but "Open Recent Git Project" doesn't, so I added it to openRecentProjects. Also, that function passes openInNewWindow to openProject; it is the same way to showProjectList.